### PR TITLE
Put babel-polyfill to webpack configuration entry

### DIFF
--- a/webpack/config.development.js
+++ b/webpack/config.development.js
@@ -6,6 +6,7 @@ var WebpackNotifierPlugin = require('webpack-notifier');
 module.exports = {
   devtool: 'source-map', // 'eval'
   entry: [
+    'babel-polyfill',
     'webpack-hot-middleware/client',
     './src/index'
   ],

--- a/webpack/config.production.js
+++ b/webpack/config.production.js
@@ -6,6 +6,7 @@ var DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");
 
 module.exports = {
   entry: [
+    'babel-polyfill',
     './src/index'
   ],
   output: {

--- a/webpack/config.test.js
+++ b/webpack/config.test.js
@@ -5,6 +5,7 @@ var DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");
 module.exports = {
   devtool: 'eval',
   entry: [
+    'babel-polyfill',
     'webpack-hot-middleware/client',
     './src/index'
   ],


### PR DESCRIPTION
Hi Sebastian

For us it was necessary to add the babel-poliyfill to webpack configuration in order to let it be runnable on Internet Explorer 11.

HTH
Cheers Raffael
